### PR TITLE
Retain the `@wiki.tree_map_for()` cache.

### DIFF
--- a/lib/gollum-lib/page.rb
+++ b/lib/gollum-lib/page.rb
@@ -477,7 +477,7 @@ module Gollum
       
       map ||= @wiki.tree_map_for(@wiki.ref, true)
       valid_names = subpagenames.map(&:capitalize).join("|")
-      while entry = map.shift do
+      map.each do |entry|
         next unless entry.name =~ /^_(#{valid_names})/
         sub_page_type = ::File.basename(entry.name.downcase.tr('_', ''), ::File.extname(entry.name))
         next if instance_variable_get("@#{sub_page_type}")


### PR DESCRIPTION
`map.shift` will clear the tree map cache, if the find_sub_pages executed once, the cache of the tree map turned into an empty array, and will not be updated, because of an empty array is not nil.
